### PR TITLE
MMT/BJMM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,16 @@ tests/test_permute
 tests/test_prange
 tests/test_marc
 tests/test_collect
-tests/test_mdeumer
+tests/test_dummer
 tests/test_unordered_multimap
+tests/test_mmt
 
 /.vs
 /vs2022/.vs/isdsolver
 Debug
 Release
+.idea/
+build/
+cmake-build-debug/
+cmake-build-release/
+CMakeLists.txt

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ tests/test_parser
 tests/test_permute
 tests/test_prange
 tests/test_marc
+tests/test_collect
+tests/test_mdeumer
+tests/test_unordered_multimap
+
 /.vs
 /vs2022/.vs/isdsolver
 Debug

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ build/
 cmake-build-debug/
 cmake-build-release/
 CMakeLists.txt
+.cache/

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,8 @@ libmccl_la_SOURCES=\
 	mccl/algorithm/lee_brickell.cpp \
 	mccl/algorithm/stern_dumer.hpp \
 	mccl/algorithm/stern_dumer.cpp \
+	mccl/algorithm/mmt.hpp \
+	mccl/algorithm/mmt.cpp \
 	\
 	mccl/tools/parser.hpp \
 	mccl/tools/parser.cpp \
@@ -51,9 +53,9 @@ libmccl_la_SOURCES=\
 bin_isdsolver_SOURCES= src/isdsolver.cpp
 bin_isdsolver_LDADD  = libmccl.la
 
-TESTS=          tests/test_compile tests/test_unordered_multimap tests/test_matrix tests/test_parser tests/test_prange tests/test_dumer tests/test_collection
+TESTS=          tests/test_compile tests/test_unordered_multimap tests/test_matrix tests/test_parser tests/test_prange tests/test_dumer tests/test_mmt tests/test_collection
 
-check_PROGRAMS= tests/test_compile tests/test_unordered_multimap tests/test_matrix tests/test_parser tests/test_prange tests/test_dumer tests/test_collection
+check_PROGRAMS= tests/test_compile tests/test_unordered_multimap tests/test_matrix tests/test_parser tests/test_prange tests/test_dumer tests/test_mmt tests/test_collection
 
 tests_test_compile_SOURCES= tests/test_compile.cpp
 tests_test_compile_LDADD  = libmccl.la
@@ -72,6 +74,9 @@ tests_test_prange_LDADD  = libmccl.la
 
 tests_test_dumer_SOURCES= tests/test_dumer.cpp
 tests_test_dumer_LDADD  = libmccl.la
+
+tests_test_mmt_SOURCES= tests/test_mmt.cpp
+tests_test_mmt_LDADD  = libmccl.la
 
 tests_test_collection_SOURCES= tests/test_collection.cpp
 tests_test_collection_LDADD  = libmccl.la

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function docmd
 {

--- a/mccl/algorithm/mmt.cpp
+++ b/mccl/algorithm/mmt.cpp
@@ -1,0 +1,26 @@
+#include <mccl/algorithm/mmt.hpp>
+
+MCCL_BEGIN_NAMESPACE
+
+mmt_config_t mmt_config_default;
+
+vec solve_SD_mmt(const cmat_view& H, const cvec_view& S, unsigned int w)
+{
+    subISDT_mmt subISDT;
+    ISD_mmt<> ISD(subISDT);
+    
+    return solve_SD(ISD, H, S, w);
+}
+
+vec solve_SD_mmt(const cmat_view& H, const cvec_view& S, unsigned int w, const configmap_t& configmap)
+{
+    subISDT_mmt subISDT;
+    ISD_mmt<> ISD(subISDT);
+    
+    subISDT.load_config(configmap);
+    ISD.load_config(configmap);
+    
+    return solve_SD(ISD, H, S, w);
+}
+
+MCCL_END_NAMESPACE

--- a/mccl/algorithm/mmt.hpp
+++ b/mccl/algorithm/mmt.hpp
@@ -26,12 +26,16 @@ struct mmt_config_t
 
     unsigned int p = 4;
     unsigned int l1 = 6;
+	unsigned int bucketsize = 10;
 
     template<typename Container>
     void process(Container& c)
     {
         c(p, "p", 4, "subISDT parameter p");
         c(l1, "l1", 6, "subISDT parameter l1");
+
+		// TODO one can compute this directly. 
+        c(bucketsize, "bucketsize", 10, "subISDT parameter bucketsize");
     }
 };
 
@@ -49,7 +53,6 @@ class SimpleHashMap {
 public:
     typedef keyType 	T;
 
-    // TODO make sure that is general enough
     typedef size_t 		LoadType;
     typedef size_t 		IndexType;
 
@@ -73,12 +76,9 @@ public:
 
 	}
 
-    /// the simple hashmap ignores the thread id.
-    /// Which is nice.
     /// \param e key element (hashed down = index within the internal array)
     /// \param value element to insert
     /// \param tid (ignored) can be anything
-    /// \return
     void insert(const keyType &e,
                           const valueType value,
                           const uint32_t tid) noexcept {
@@ -86,9 +86,6 @@ public:
         insert(e, value);
     }
 
-    /// hashes down `e` (Element) to an index where to store
-    /// the element.
-    /// NOTE: Boundary checks are performed in debug mode.
     /// \param e element to insert
     /// \return nothing
     void insert(const keyType &e, const valueType value) noexcept {
@@ -115,8 +112,6 @@ public:
 
     }
 
-    /// Quite same to `probe` but instead it will directly return
-    /// the position of the element.
     /// \param e Element to hash down.
     /// \return the position within the internal const_array of `e`
     inline index_type find(const keyType &e) const noexcept {
@@ -232,7 +227,7 @@ public:
         l1mask = detail::lastwordmask(l1);
         helpermask = detail::lastwordmask(16*p1);
 		
-		hashmap_bucketsize = 10;
+		hashmap_bucketsize = config.bucketsize;
         hashmap = new HMType{hashmap_bucketsize, 1u << l1};
 
         // TODO: compute a reasonable reserve size

--- a/mccl/algorithm/mmt.hpp
+++ b/mccl/algorithm/mmt.hpp
@@ -1,0 +1,456 @@
+#ifndef MCCL_ALGORITHM_MMT_HPP
+#define MCCL_ALGORITHM_MMT_HPP
+
+#include <mccl/config/config.hpp>
+#include <mccl/algorithm/decoding.hpp>
+#include <mccl/algorithm/isdgeneric.hpp>
+#include <mccl/tools/unordered_multimap.hpp>
+#include <mccl/tools/bitfield.hpp>
+#include <mccl/tools/enumerate.hpp>
+
+#include <unordered_map>
+#include <type_traits>
+
+MCCL_BEGIN_NAMESPACE
+
+struct mmt_config_t
+{
+    const std::string modulename = "mmt";
+    const std::string description = "mmt configuration";
+    const std::string manualstring = 
+        "MMT:\n"
+        "\tParameters: p, l1\n"
+        "\tAlgorithm:\n"
+        "\t\tPartition columns of H2 into two sets.\n\t\tCompare p/2-columns sums from both sides.\n\t\tReturn pairs that sum up to S2.\n"
+        ;
+
+    unsigned int p = 4;
+    unsigned int l1 = 6;
+
+    template<typename Container>
+    void process(Container& c)
+    {
+        c(p, "p", 4, "subISDT parameter p");
+        c(l1, "l1", 6, "subISDT parameter l1");
+    }
+};
+
+// global default. modifiable.
+// at construction of subISDT_mmt the current global default values will be loaded
+extern mmt_config_t mmt_config_default;
+
+template<
+        typename keyType,
+        typename valueType,
+        class Hash>
+class SimpleHashMap {
+    using data_type          = valueType;
+    using index_type         = size_t;
+
+public:
+    typedef keyType 	T;
+
+    // TODO make sure that is general enough
+    typedef size_t 		LoadType;
+    typedef size_t 		IndexType;
+
+    // size per bucket
+    const static size_t bucketsize = 100u;
+
+    // number of buckets
+    const static size_t nrbuckets = 1u << 6u;
+
+    // total number of elements in the HM
+    const static size_t total_size = bucketsize * nrbuckets;
+
+    using load_type = uint16_t;
+
+    /// constructor. Zero initializing everything
+    SimpleHashMap() noexcept :
+            __internal_hashmap_array(),
+            __internal_load_array() {}
+
+    /// the simple hashmap ignores the thread id.
+    /// Which is nice.
+    /// \param e key element (hashed down = index within the internal array)
+    /// \param value element to insert
+    /// \param tid (ignored) can be anything
+    /// \return
+    void insert(const keyType &e,
+                          const valueType value,
+                          const uint32_t tid) noexcept {
+        (void)tid;
+        insert(e, value);
+    }
+
+    /// hashes down `e` (Element) to an index where to store
+    /// the element.
+    /// NOTE: Boundary checks are performed in debug mode.
+    /// \param e element to insert
+    /// \return nothing
+    void insert(const keyType &e, const valueType value) noexcept {
+        // hash down the element to the index
+        const size_t index = e;
+        assert(e < nrbuckets);
+        size_t load = __internal_load_array[index];
+
+        // early exit, if it's already full
+        if (load == bucketsize) {
+           return ;
+        }
+
+
+        // just some debugging checks
+        __internal_load_array[index] += 1;
+
+        /// NOTE: this store never needs to be atomic, as the position was
+        /// computed atomically.
+        if constexpr (std::is_array<data_type>::value) {
+            memcpy(__internal_hashmap_array[index*bucketsize + load], value, sizeof(data_type));
+        } else {
+            __internal_hashmap_array[index*bucketsize + load] = value;
+        }
+
+    }
+
+    /// Quite same to `probe` but instead it will directly return
+    /// the position of the element.
+    /// \param e Element to hash down.
+    /// \return the position within the internal const_array of `e`
+    index_type find(const keyType &e) const noexcept {
+        const index_type index = e;
+        assert(e < nrbuckets);
+        // return the index instead of the actual element, to
+        // reduce the size of the returned element.
+        return index*nrbuckets;
+    }
+
+    constexpr index_type find(const keyType &e, index_type &__load) const noexcept {
+        const index_type index = e;
+        assert(e < nrbuckets);
+        __load = __internal_load_array[index];
+        // return the index instead of the actual element, to
+        // reduce the size of the returned element.
+        return index*nrbuckets;
+    }
+
+    /// prints the content of each bucket
+    /// it with one thread.
+    /// \return nothing
+    void print() const noexcept {
+        for (index_type i = 0; i < nrbuckets; i++) {
+            std::cout << "Bucket: " << i << ", load: " << size_t(__internal_load_array[i]) << "\n";
+
+            for (index_type j = 0; j < bucketsize; j++) {
+                print(i*bucketsize + j);
+            }
+        }
+    }
+
+
+    /// NOTE: can be called with only a single thread
+    /// overwrites the internal data const_array
+    /// with zero initialized elements.
+    void clear() noexcept {
+        memset(__internal_load_array.data(), 0, nrbuckets*sizeof(load_type));
+    }
+
+    // internal const_array
+    alignas(1024) std::array<data_type, total_size> __internal_hashmap_array;
+    alignas(1024) std::array<load_type, nrbuckets> __internal_load_array;
+};
+
+
+
+class subISDT_mmt
+    final : public subISDT_API
+{
+public:
+    using subISDT_API::callback_t;
+
+
+    struct StupidHasher {
+        static std::size_t operator()(const uint32_t &k) {
+            return k&l1mask;
+        }
+
+        static const uint64_t l1mask = (1u << 6u) - 1u;
+    };
+
+    using HMType = SimpleHashMap<uint64_t, std::pair<uint32_t, uint32_t>, StupidHasher>;
+
+    // API member function
+    ~subISDT_mmt() final
+    {
+        cpu_prepareloop.refresh();
+        cpu_loopnext.refresh();
+        cpu_callback.refresh();
+        if (cpu_loopnext.total() > 0)
+        {
+            std::cerr << "prepare : " << cpu_prepareloop.total() << std::endl;
+            std::cerr << "nextloop: " << cpu_loopnext.total() - cpu_callback.total() << std::endl;
+            std::cerr << "callback: " << cpu_callback.total() << std::endl;
+        }
+    }
+    
+    subISDT_mmt()
+        : config(mmt_config_default), stats("MMT")
+    {
+        hashmap = new HMType{};
+    }
+
+    void load_config(const configmap_t& configmap) final
+    {
+        mccl::load_config(config, configmap);
+    }
+    void save_config(configmap_t& configmap) final
+    {
+        mccl::save_config(config, configmap);
+    }
+
+    // API member function
+    void initialize(const cmat_view& _H12T,
+                    size_t _H2Tcolumns,
+                    const cvec_view& _S,
+                    unsigned int w,
+                    callback_t _callback,
+                    void* _ptr) final {
+        if (stats.cnt_initialize._counter != 0) {
+            stats.refresh();
+        }
+        stats.cnt_initialize.inc();
+
+        // copy initialization parameters
+        H12T.reset(_H12T);
+        S.reset(_S);
+        columns = _H2Tcolumns;
+        callback = _callback;
+        ptr = _ptr;
+
+        // copy parameters from current config
+        p = config.p;
+        // set attack parameters
+        p1 = p/4;
+        l1 = config.l1;
+        rows = H12T.rows();
+        rows1 = rows/2; rows2 = rows - rows1;
+
+        words = (columns+63)/64;
+
+        // check configuration
+        if (p % 4)
+            throw std::runtime_error("subISDT_mmt::initialize: MMT does not support p % 4 != 0");
+        if (columns < 6)
+            throw std::runtime_error("subISDT_mmt::initialize: MMT does not support l < 6 (since we use bitfield)");
+        if (words > 1)
+            throw std::runtime_error("subISDT_mmt::initialize: MMT does not support l > 64 (yet)");
+        if ( p1 > 3)
+            throw std::runtime_error("subISDT_mmt::initialize: MMT does not support p > 3 (yet)");
+        if (rows1 >= 65535 || rows2 >= 65535)
+            throw std::runtime_error("subISDT_mmt::initialize: MMT does not support rows1 or rows2 >= 65535");
+        if (l1 >= columns)
+            throw std::runtime_error("subISDT_mmt::initialize: MMT does not support l1 >= l");
+
+        firstwordmask = detail::lastwordmask(columns);
+        l1mask = detail::lastwordmask(l1);
+        helpermask = detail::lastwordmask(16*p1);
+
+
+        // TODO: compute a reasonable reserve size
+        // hashmap.reserve(...);
+    }
+
+    // API member function
+    void solve() final
+    {
+        stats.cnt_solve.inc();
+        prepare_loop();
+        while (loop_next())
+            ;
+    }
+    
+    // API member function
+    void prepare_loop() final
+    {
+        stats.cnt_prepare_loop.inc();
+        MCCL_CPUCYCLE_STATISTIC_BLOCK(cpu_prepareloop);
+        
+        firstwords.resize(rows);
+        for (unsigned i = 0; i < rows; ++i)
+            firstwords[i] = (*H12T.word_ptr(i)) & firstwordmask;
+        Sval = (*S.word_ptr()) & firstwordmask;
+        // TODO rand sucks
+        iTl = rand() & l1mask;
+        iTr = (Sval ^ iTl);
+        
+        hashmap->clear();
+        Ihashmap.clear();
+    }
+
+    // API member function
+    bool loop_next() final
+    {
+        stats.cnt_loop_next.inc();
+        MCCL_CPUCYCLE_STATISTIC_BLOCK(cpu_loopnext);
+
+        // fill the first hashmap
+        enumerate.enumerate(firstwords.data()+0, firstwords.data()+rows2, p1,
+            [this](const uint32_t* idxbegin, const uint32_t* idxend, uint64_t val)
+            {
+                hashmap->insert(val&l1mask,
+                                std::pair<uint32_t, uint32_t>(val, pack_indices(idxbegin, idxend)));
+            });
+
+        // fill the intermediate list
+        enumerate.enumerate(firstwords.data()+rows2, firstwords.data()+rows, p1,
+            [this](const uint32_t* idxbegin, const uint32_t* idxend, uint64_t val)
+            {
+                val ^= iTl;
+                const uint64_t val2 = val & l1mask;
+
+                auto it = idx;
+                for (auto it2 = idxbegin; it2 != idxend; ++it2,++it) {
+                    *it = *it2 + rows2;
+                }
+                const uint64_t tmp = pack_indices(idx, it) << (p1*16);
+
+                const size_t hashmap_offset = val2*hashmap_bucketsize;
+                const size_t left_load = hashmap->__internal_load_array[val2];
+                for (auto iter = hashmap->__internal_hashmap_array.begin() + hashmap_offset;
+                     iter != hashmap->__internal_hashmap_array.begin() + hashmap_offset + left_load;
+                     iter++) {
+
+                    const uint64_t val3 = val ^ iter->first;
+                    assert((val3 & l1mask) == 0);
+                    const uint64_t tmp2 = tmp ^ (iter->second & helpermask);
+                    Ihashmap.emplace(val3 >> l1, tmp2);
+                }
+            });
+
+        // find collisions on the right side of the tree
+        enumerate.enumerate(firstwords.data()+rows2, firstwords.data()+rows, p1,
+            [this](const uint32_t* idxbegin, const uint32_t* idxend, uint64_t val)
+            {
+                val ^= iTr;
+                const uint64_t val2 = val & l1mask;
+
+                uint32_t* it = idx;
+                for (auto it2 = idxbegin; it2 != idxend; ++it2,++it) {
+                    *it = *it2 + rows2;
+                }
+
+                const size_t hashmap_offset = val2*hashmap_bucketsize;
+                const size_t left_load = hashmap->__internal_load_array[val2];
+                for (auto iter = hashmap->__internal_hashmap_array.begin() + hashmap_offset;
+                     iter != hashmap->__internal_hashmap_array.begin() + hashmap_offset + left_load;
+                     iter++) {
+
+                    uint64_t val3 = val^iter->first;
+                    assert((val3 & l1mask) == 0);
+                    val3 >>= l1;
+                    auto *it2 = unpack_indices(iter->second, it, 1);
+
+                    auto range = Ihashmap.equal_range(val3);
+                    for (auto valit = range.first; valit != range.second; ++valit){
+                        assert((val3 ^ valit->first) == 0);
+                        uint64_t packed_indices = valit->second;
+                        auto *it3 = unpack_indices(packed_indices, it2, 2);
+
+                        uint64_t kek = 0;
+                        for (uint32_t i = 0; i < p; i++){
+                            kek ^= firstwords[idx[i]];
+                        }
+                        assert((kek ^ Sval) == 0);
+                        MCCL_CPUCYCLE_STATISTIC_BLOCK(cpu_callback);
+                        if (!(*callback)(ptr, idx+0, it3, 0)) {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            });
+        return false;
+    }
+
+    static uint64_t pack_indices(const uint32_t* begin, const uint32_t* end)
+    {
+        uint64_t x = ~uint64_t(0);
+        for (; begin != end; ++begin)
+        {
+            x <<= 16;
+            x |= uint64_t(*begin);
+        }
+        return x;
+    }
+
+    uint32_t* unpack_indices(uint64_t x, uint32_t* first, const uint32_t nr)
+    {
+        for (size_t i = 0; i < nr; ++i)
+        {
+            uint32_t y = uint32_t(x & 0xFFFF);
+            if (y == 0xFFFF)
+                break;
+            *first = y;
+            ++first;
+            x >>= 16;
+        }
+        return first;
+    }
+
+
+    decoding_statistics get_stats() const { return stats; };
+
+
+private:
+
+
+    callback_t callback;
+    void* ptr;
+    cmat_view H12T;
+    cvec_view S;
+    size_t columns, words;
+
+    enumerate_t<uint32_t> enumerate;
+
+    std::vector<uint64_t> firstwords;
+    uint64_t firstwordmask, l1mask, helpermask, Sval, iTl, iTr;
+
+    uint32_t idx[16] = {0};
+
+    size_t p, l1, p1, rows, rows1, rows2;
+    
+    mmt_config_t config;
+    decoding_statistics stats;
+    cpucycle_statistic cpu_prepareloop, cpu_loopnext, cpu_callback;
+
+    // std::unordered_multimap<uint64_t, uint64_t, StupidHasher, StupidCMP> hashmap;
+    HMType *hashmap;
+    std::unordered_multimap<uint64_t, uint64_t> Ihashmap;
+
+    /// TODO use it
+    uint32_t hashmap_bucketsize = 100;
+};
+
+
+
+template<size_t _bit_alignment = 64>
+using ISD_mmt = ISD_generic<subISDT_mmt,_bit_alignment>;
+
+vec solve_SD_mmt(const cmat_view& H, const cvec_view& S, unsigned int w);
+static inline vec solve_SD_mmt(const syndrome_decoding_problem& SD)
+{
+    return solve_SD_mmt(SD.H, SD.S, SD.w);
+}
+
+vec solve_SD_mmt(const cmat_view& H, const cvec_view& S, unsigned int w, const configmap_t& configmap);
+static inline vec solve_SD_mmt(const syndrome_decoding_problem& SD, const configmap_t& configmap)
+{
+    return solve_SD_mmt(SD.H, SD.S, SD.w, configmap);
+}
+
+
+
+MCCL_END_NAMESPACE
+
+#endif

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,7 @@ stdenv.mkDerivation {
   src = ./.;
 
   buildInputs = [ 
+    cmake
     gmp
 	libtool 
 	autoconf 
@@ -13,6 +14,7 @@ stdenv.mkDerivation {
 	autogen 
 	gnumake 
 	clang_16
+	llvm_16
 	gcc
   ] ++ (lib.optionals pkgs.stdenv.isLinux ([
 	flamegraph

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+
+stdenv.mkDerivation {
+  name = "cryptanalysislib";
+  src = ./.;
+
+  buildInputs = [ 
+    gmp
+	libtool 
+	autoconf 
+	automake 
+	autogen 
+	gnumake 
+	clang_16
+	gcc
+  ] ++ (lib.optionals pkgs.stdenv.isLinux ([
+	flamegraph
+	gdb
+    linuxKernel.packages.linux_6_5.perf
+	pprof
+	valgrind
+	massif-visualizer
+  ]));
+}

--- a/src/isdsolver.cpp
+++ b/src/isdsolver.cpp
@@ -6,6 +6,7 @@
 #include <mccl/algorithm/prange.hpp>
 #include <mccl/algorithm/lee_brickell.hpp>
 #include <mccl/algorithm/stern_dumer.hpp>
+#include <mccl/algorithm/mmt.hpp>
 
 #include <mccl/tools/parser.hpp>
 #include <mccl/tools/generator.hpp>
@@ -174,6 +175,7 @@ try
     modules.emplace_back( make_module_configuration( ISD_generic_config_default ) );
     modules.emplace_back( make_module_configuration( lee_brickell_config_default ) );
     modules.emplace_back( make_module_configuration( stern_dumer_config_default ) );
+    modules.emplace_back( make_module_configuration( mmt_config_default ) );
     // =================================================================
     
     //  if there are common options then only the first description is used

--- a/tests/test_mmt.cpp
+++ b/tests/test_mmt.cpp
@@ -1,0 +1,61 @@
+#include <mccl/config/config.hpp>
+
+#include <mccl/tools/parser.hpp>
+#include <mccl/algorithm/isdgeneric.hpp>
+#include <mccl/algorithm/mmt.hpp>
+
+#include "test_utils.hpp"
+
+#include <iostream>
+#include <vector>
+
+using namespace mccl;
+
+int main(int, char**)
+{
+    int status = 0;
+
+    file_parser parse;
+    status |= !parse.parse_file("../tests/data/SD_100_0");
+
+    auto Hraw = parse.H();
+    auto S = parse.S();
+    size_t n = parse.n();
+    size_t k = parse.k();
+    size_t w = parse.w();
+
+    std::vector<size_t> rowweights(n-k);
+    for( size_t r = 0; r < n-k; r++)
+        rowweights[r] = hammingweight(Hraw[r]);
+//    auto total_hw = hammingweight(Hraw);
+
+    configmap_t configmap = { {"p", "4"}, {"l", "14"} };
+    {
+        subISDT_mmt mmt;
+        ISD_generic<subISDT_mmt> ISD_mmt(mmt);
+        
+        ISD_mmt.load_config(configmap);
+        mmt.load_config(configmap);
+        
+        ISD_mmt.initialize(Hraw, S, w);
+        ISD_mmt.solve();
+        status |= not(hammingweight(ISD_mmt.get_solution()) <= w);
+        std::cerr << hammingweight(ISD_mmt.get_solution()) << std::endl;
+        vec eval_S(Hraw.rows());
+        vec r(Hraw.columns());
+        for(size_t i = 0; i < Hraw.rows(); i++ ) 
+        {
+            bool x = hammingweight(r.v_and(Hraw[i],ISD_mmt.get_solution()))%2;
+            if(x)
+                eval_S.setbit(i);
+        }
+        status |= not(eval_S.is_equal(S));
+    }
+
+    if (status == 0)
+    {
+        LOG_CERR("All tests passed.");
+        return 0;
+    }
+    return -1;
+}


### PR DESCRIPTION
This PR adds a very simple implementation of the MMT/BJMM algorithm. Additionally the following small changes were done:
- updated `.gitignore` to actually ignore everything
- update `build.sh` to run on `nixos`
- add a `shell.nix` to be able to run the library on `nixos`

Note the following optimization strategies are missing:
- TMTO from EC '23 
- global/partial solutions are not checked in batches

Also note that I need a custom "hashmap" implementation for the baselist L1, because I need a special hashing on the first `l1` bits but still save the whole `l` bits. This hashmap should to be replaced with `std::unordered_multimap` or something else, but when I tried I got weird errors. So there is still something todo.